### PR TITLE
Added `disableLightnessSlider` and `disableColorCode` attributes

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -106,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/lib/flutter_circle_color_picker.dart
+++ b/lib/flutter_circle_color_picker.dart
@@ -150,9 +150,7 @@ class _CircleColorPickerState extends State<CircleColorPicker>
                                   '#${_color.value.toRadixString(16).substring(2)}',
                                   style: widget.textStyle,
                                 ),
-                        SizedBox(
-                          height: widget.disableColorCode ? 0 : 16,
-                        ),
+                        const SizedBox(height: 16),
                         Container(
                           width: 64,
                           height: 64,
@@ -169,9 +167,7 @@ class _CircleColorPickerState extends State<CircleColorPicker>
                             ),
                           ),
                         ),
-                        SizedBox(
-                          height: widget.disableLightnessSlider ? 0 : 16,
-                        ),
+                        const SizedBox(height: 16),
                         if (!widget.disableLightnessSlider)
                           _LightnessSlider(
                             width: 140,

--- a/lib/flutter_circle_color_picker.dart
+++ b/lib/flutter_circle_color_picker.dart
@@ -28,6 +28,8 @@ class CircleColorPicker extends StatefulWidget {
     this.strokeWidth = 2,
     this.thumbSize = 32,
     this.controller,
+    this.disableLightnessSlider = false,
+    this.disableColorCode = false,
     this.textStyle = const TextStyle(
       fontSize: 24,
       fontWeight: FontWeight.bold,
@@ -78,6 +80,16 @@ class CircleColorPicker extends StatefulWidget {
   ///
   /// Default is Text widget that shows rgb strings;
   final ColorCodeBuilder? colorCodeBuilder;
+
+  /// Determines whether to draw the [colorCodeBuilder]
+  ///
+  /// Default value is false
+  final bool disableColorCode;
+
+  /// Determines whether to draw the [_LightnessSlider]
+  ///
+  /// Default value is false
+  final bool disableLightnessSlider;
 
   Color get initialColor =>
       controller?.color ?? const Color.fromARGB(255, 255, 0, 0);
@@ -131,13 +143,16 @@ class _CircleColorPickerState extends State<CircleColorPicker>
                     child: Column(
                       mainAxisSize: MainAxisSize.min,
                       children: <Widget>[
-                        widget.colorCodeBuilder != null
-                            ? widget.colorCodeBuilder!(context, _color)
-                            : Text(
-                                '#${_color.value.toRadixString(16).substring(2)}',
-                                style: widget.textStyle,
-                              ),
-                        const SizedBox(height: 16),
+                        if (!widget.disableColorCode)
+                          widget.colorCodeBuilder != null
+                              ? widget.colorCodeBuilder!(context, _color)
+                              : Text(
+                                  '#${_color.value.toRadixString(16).substring(2)}',
+                                  style: widget.textStyle,
+                                ),
+                        SizedBox(
+                          height: widget.disableColorCode ? 0 : 16,
+                        ),
                         Container(
                           width: 64,
                           height: 64,
@@ -154,17 +169,20 @@ class _CircleColorPickerState extends State<CircleColorPicker>
                             ),
                           ),
                         ),
-                        const SizedBox(height: 16),
-                        _LightnessSlider(
-                          width: 140,
-                          thumbSize: 26,
-                          hue: _hueController.value,
-                          lightness: _lightnessController.value,
-                          onEnded: _onEnded,
-                          onChanged: (lightness) {
-                            _lightnessController.value = lightness;
-                          },
+                        SizedBox(
+                          height: widget.disableLightnessSlider ? 0 : 16,
                         ),
+                        if (!widget.disableLightnessSlider)
+                          _LightnessSlider(
+                            width: 140,
+                            thumbSize: 26,
+                            hue: _hueController.value,
+                            lightness: _lightnessController.value,
+                            onEnded: _onEnded,
+                            onChanged: (lightness) {
+                              _lightnessController.value = lightness;
+                            },
+                          ),
                       ],
                     ),
                   );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -92,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Added `disableLightnessSlider` and `disableColorCode` attributes to determine whether or not those Widgets should render.
I am using this package to control an RGB LED and the lightness slider isn't needed and also the hex code may be confusing to some users. 