### PR TITLE
Add onTap callback with splash to the centre circle

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ A beautiful circle color picker for flutter. [Online Demo](https://itome.github.
   /// This callback called with latest color that user selected.
   final ValueChanged<Color>? onEnded;
 
+/// Called when the center circle is tapped.
+///
+/// This callback called with latest color that user selected.
+final ValueChanged<Color>? onTap;
+
   /// An object to controll picker color dynamically.
   ///
   /// Provide initialColor if needed.

--- a/lib/flutter_circle_color_picker.dart
+++ b/lib/flutter_circle_color_picker.dart
@@ -144,23 +144,29 @@ class _CircleColorPickerState extends State<CircleColorPicker>
                                 style: widget.textStyle,
                               ),
                         const SizedBox(height: 16),
-                        InkWell(
-                            child: Container(
-                              width: 64,
-                              height: 64,
-                              decoration: BoxDecoration(
-                                color: _color,
-                                shape: BoxShape.circle,
-                                border: Border.all(
+                        Material(
+                          child: Ink(
+                            child: InkWell(
+                                customBorder: CircleBorder(),
+                                onTap: (widget.onTap != null)
+                                    ? () => widget.onTap?.call(_color)
+                                    : null),
+                            width: 64,
+                            height: 64,
+                            decoration: BoxDecoration(
+                              color: _color,
+                              shape: BoxShape.circle,
+                              border: Border.all(
                                   width: 3,
                                   color: HSLColor.fromColor(_color)
                                       .withLightness(
-                                    _lightnessController.value * 4 / 5,
-                                  )
-                                      .toColor(),
-                                ),
-                              ),
-                            ), onTap: _onTap),
+                                        _lightnessController.value * 4 / 5,
+                                      )
+                                      .toColor()),
+                            ),
+                          ),
+                          shape: const CircleBorder(),
+                        ),
                         const SizedBox(height: 16),
                         _LightnessSlider(
                           width: 140,
@@ -215,10 +221,6 @@ class _CircleColorPickerState extends State<CircleColorPicker>
 
   void _onEnded() {
     widget.onEnded?.call(_color);
-  }
-
-  void _onTap() {
-    widget.onTap?.call(_color);
   }
 
   void _setColor() {

--- a/lib/flutter_circle_color_picker.dart
+++ b/lib/flutter_circle_color_picker.dart
@@ -24,6 +24,7 @@ class CircleColorPicker extends StatefulWidget {
     Key? key,
     this.onChanged,
     this.onEnded,
+    this.onTap,
     this.size = const Size(280, 280),
     this.strokeWidth = 2,
     this.thumbSize = 32,
@@ -45,6 +46,11 @@ class CircleColorPicker extends StatefulWidget {
   ///
   /// This callback called with latest color that user selected.
   final ValueChanged<Color>? onEnded;
+
+  /// Called when the center circle is tapped.
+  ///
+  /// This callback called with latest color that user selected.
+  final ValueChanged<Color>? onTap;
 
   /// An object to controll picker color dynamically.
   ///
@@ -138,22 +144,23 @@ class _CircleColorPickerState extends State<CircleColorPicker>
                                 style: widget.textStyle,
                               ),
                         const SizedBox(height: 16),
-                        Container(
-                          width: 64,
-                          height: 64,
-                          decoration: BoxDecoration(
-                            color: _color,
-                            shape: BoxShape.circle,
-                            border: Border.all(
-                              width: 3,
-                              color: HSLColor.fromColor(_color)
-                                  .withLightness(
+                        InkWell(
+                            child: Container(
+                              width: 64,
+                              height: 64,
+                              decoration: BoxDecoration(
+                                color: _color,
+                                shape: BoxShape.circle,
+                                border: Border.all(
+                                  width: 3,
+                                  color: HSLColor.fromColor(_color)
+                                      .withLightness(
                                     _lightnessController.value * 4 / 5,
                                   )
-                                  .toColor(),
-                            ),
-                          ),
-                        ),
+                                      .toColor(),
+                                ),
+                              ),
+                            ), onTap: _onTap),
                         const SizedBox(height: 16),
                         _LightnessSlider(
                           width: 140,
@@ -208,6 +215,10 @@ class _CircleColorPickerState extends State<CircleColorPicker>
 
   void _onEnded() {
     widget.onEnded?.call(_color);
+  }
+
+  void _onTap() {
+    widget.onTap?.call(_color);
   }
 
   void _setColor() {


### PR DESCRIPTION
@itome I love the simplicity of your widget.  

In my case though, I need to be able to "capture" clicks so I know when the user has finished with the widget and is ready to close the overlay, so I've added an optional `onTap` callback for the centre circle, and moved from a `Container()` to an `InkWell()` so that there's a splash effect when the circle is clicked (but only if there's an onTap callback).